### PR TITLE
Disable server TLS if no certificate/key provided

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -51,7 +51,8 @@ if [ "$KEY_PATH" ] && [ "$CERTIFICATE_PATH" ]; then
 	chmod 640 /etc/exim4/exim.key
 	chmod 640 /etc/exim4/exim.crt
 else
-	  echo "MAIN_TLS_ENABLE = no" >>  /etc/exim4/exim4.conf.localmacros
+	  echo "MAIN_TLS_ENABLE = no" >> /etc/exim4/exim4.conf.localmacros
+	  echo "MAIN_TLS_ADVERTISE_HOSTS = !*" >> /etc/exim4/exim4.conf.localmacros
 fi
 
 opts=(

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -50,6 +50,8 @@ if [ "$KEY_PATH" ] && [ "$CERTIFICATE_PATH" ]; then
 	chgrp Debian-exim /etc/exim4/exim.crt
 	chmod 640 /etc/exim4/exim.key
 	chmod 640 /etc/exim4/exim.crt
+else
+	  echo "MAIN_TLS_ENABLE = no" >>  /etc/exim4/exim4.conf.localmacros
 fi
 
 opts=(


### PR DESCRIPTION
Current exim version enables TLS by default for the server and generates a self-signed certificate. When a client tries to send an e-mail it will likely fail as it cannot verify the certificate. This change disables server support for TLS so clients can connect without verifying the certificate. TLS usage for connecting to remote mail servers remains enabled.

