### PR TITLE
Debian-exim group ID is not guaranteed to be stable

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -60,7 +60,7 @@ fi
 
 if [ "$DKIM_KEY_PATH" ]; then
 	cp "$DKIM_KEY_PATH" /etc/exim4/dkim.key
-	chown :101 /etc/exim4/dkim.key
+	chown Debian-exim /etc/exim4/dkim.key
 	chmod 640 /etc/exim4/dkim.key
 	{
 		echo "DKIM_DOMAIN = \${lc:\${domain:\$h_from:}}"


### PR DESCRIPTION
In my build of 0.5.0, the group ID is not 101. Looks like it's not stable across builds.

```
root@30de5a944fde:/etc/exim4# id Debian-exim
uid=100(Debian-exim) gid=102(Debian-exim) groups=102(Debian-exim)
```